### PR TITLE
Work around xDrip not returning glucose readings from BYO Dexcom app.

### DIFF
--- a/modules/companion/settings.js
+++ b/modules/companion/settings.js
@@ -92,6 +92,8 @@ export default class settings {
       if (dataReceivedFromWatch && dataReceivedFromWatch != null) {
         queryParms = `?count=47&steps=${dataReceivedFromWatch.steps}&heart=${dataReceivedFromWatch.heart}`;
       }
+      // Include data even if not from the current sensor (e.g. if there's no sensor)
+      queryParms += "&all_data=true";
       url = "http://127.0.0.1:17580/sgv.json" + queryParms;
     } else if (dataSource === "spike") {
       // spike


### PR DESCRIPTION
I expect this commit to fix https://github.com/Rytiggy/Glance/issues/162

Note: I have no experience with building Fitbit watchfaces so I have not tested (not even compiled) the code after this commit at all. However I have confirmed that an equivalent patch in xDrip+ fixes the issue; concretely, hardcoding ignore_sensor=true in https://github.com/jamorham/xDrip-plus/blob/master/app/src/main/java/com/eveningoutpost/dexdrip/webservices/WebServiceSgv.java#L121 (as if all_data=true had been passed) fixes the issue described in https://github.com/Rytiggy/Glance/issues/162# . Therefore, I expect this pull request to also fix that issue.

Thanks for your consideration!