### PR TITLE
Change around data to support a custom nightscout domain in settings

### DIFF
--- a/modules/companion/settings.js
+++ b/modules/companion/settings.js
@@ -38,26 +38,6 @@ export default class settings {
     let extraDataUrl = null;
     if (dataSource === "nightscout") {
       // Nightscout
-      let nightscoutSiteName = null;
-      if (
-        settingsStorage.getItem("nightscoutSiteName") &&
-        JSON.parse(settingsStorage.getItem("nightscoutSiteName")).name
-      ) {
-        nightscoutSiteName = JSON.parse(
-          settingsStorage.getItem("nightscoutSiteName")
-        ).name;
-        if (isURL(nightscoutSiteName)) {
-          nightscoutSiteName = nightscoutSiteName.split(".")[0];
-          nightscoutSiteName = nightscoutSiteName.split("//")[1];
-          console.log(nightscoutSiteName);
-        }
-      } else if (!nightscoutSiteName) {
-        nightscoutSiteName = "placeholder";
-        settingsStorage.setItem(
-          "nightscoutSiteName",
-          JSON.stringify({ name: "" })
-        );
-      }
       let nightscoutSiteHost = null;
       if (settingsStorage.getItem("nightscoutSiteHost")) {
         nightscoutSiteHost = JSON.parse(
@@ -74,19 +54,52 @@ export default class settings {
         );
       }
 
-      url =
-        "https://" +
-        nightscoutSiteName.toLowerCase() +
-        "." +
-        nightscoutSiteHost +
-        "/pebble" +
-        queryParms;
-      extraDataUrl =
-        "https://" +
-        nightscoutSiteName.toLowerCase() +
-        "." +
-        nightscoutSiteHost +
-        "/api/v2/properties";
+      let nightscoutSiteName = null;
+      if (
+        settingsStorage.getItem("nightscoutSiteName") &&
+        JSON.parse(settingsStorage.getItem("nightscoutSiteName")).name
+      ) {
+        nightscoutSiteName = JSON.parse(
+          settingsStorage.getItem("nightscoutSiteName")
+        ).name;
+        if (isURL(nightscoutSiteName)) {
+          if(nightscoutSiteHost !== "") {
+            nightscoutSiteName = nightscoutSiteName.split(".")[0];
+            nightscoutSiteName = nightscoutSiteName.split("//")[1];
+          }
+          console.log(nightscoutSiteName);
+        }
+      } else if (!nightscoutSiteName) {
+        nightscoutSiteName = "placeholder";
+        settingsStorage.setItem(
+          "nightscoutSiteName",
+          JSON.stringify({ name: "" })
+        );
+      }
+
+      if(nightscoutSiteHost === "") {
+        url =
+          nightscoutSiteName.toLowerCase() +
+          "/pebble" +
+          queryParms;
+        extraDataUrl =
+          nightscoutSiteName.toLowerCase() +
+          "/api/v2/properties";
+      } else {
+        url =
+          "https://" +
+          nightscoutSiteName.toLowerCase() +
+          "." +
+          nightscoutSiteHost +
+          "/pebble" +
+          queryParms;
+        extraDataUrl =
+          "https://" +
+          nightscoutSiteName.toLowerCase() +
+          "." +
+          nightscoutSiteHost +
+          "/api/v2/properties";
+      }
     } else if (dataSource === "xdrip") {
       // xDrip+
       if (dataReceivedFromWatch && dataReceivedFromWatch != null) {

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -55,26 +55,6 @@ function mySettings(props) {
           JSON.parse(props.settings.dataSource).values[0].value ==
           "nightscout" ? (
             <Text text="center">
-              https://<Text bold>SiteName</Text>.NightscoutHostSite.com
-            </Text>
-          ) : null
-        ) : null}
-
-        {props.settings.dataSource ? (
-          JSON.parse(props.settings.dataSource).values[0].value ==
-          "nightscout" ? (
-            <TextInput
-              title="Nightscout"
-              label="Site Name"
-              settingsKey="nightscoutSiteName"
-            />
-          ) : null
-        ) : null}
-
-        {props.settings.dataSource ? (
-          JSON.parse(props.settings.dataSource).values[0].value ==
-          "nightscout" ? (
-            <Text text="center">
               https://SiteName.<Text bold>NightscoutHostSite</Text>.com
             </Text>
           ) : null
@@ -83,12 +63,38 @@ function mySettings(props) {
           JSON.parse(props.settings.dataSource).values[0].value ==
           "nightscout" ? (
             <Select
-              label="Nightscout Host Site"
+              label="Nightscout Host"
               settingsKey="nightscoutSiteHost"
               options={[
                 { name: "Heroku", value: "herokuapp.com" },
                 { name: "Azure", value: "azurewebsites.net" },
+                { name: "Full Custom Domain", value: "" },
               ]}
+            />
+          ) : null
+        ) : null}
+
+        {props.settings.dataSource ? (
+          JSON.parse(props.settings.dataSource).values[0].value ==
+          "nightscout" ? ( (JSON.parse(props.settings.nightscoutSiteHost).values[0].value == "" ? (
+            <Text text="center">
+              <Text bold>https://FullCustomDomain.com</Text>
+            </Text>
+          ) : (
+            <Text text="center">
+              https://<Text bold>SiteName</Text>.NightscoutHostSite.com
+            </Text>
+            )
+          )
+          ) : null
+        ) : null}
+        {props.settings.dataSource ? (
+          JSON.parse(props.settings.dataSource).values[0].value ==
+          "nightscout" ? (
+            <TextInput
+              title="Nightscout"
+              label="Site Name"
+              settingsKey="nightscoutSiteName"
             />
           ) : null
         ) : null}


### PR DESCRIPTION
I changed the Nightscout data source a bit to support having a custom domain. This first includes reversing the specification of  "NightscoutHostSite" and "SiteName" (host site is now first). I've added "Custom Domain" as a "Nightscout Host" option:
![image](https://user-images.githubusercontent.com/2405631/230607954-04eca093-35e1-4032-929d-a84945bf1ab5.png)
When "Custom Domain" is selected from the Nightscout Host, the Site Name view changes to the following:
![image](https://user-images.githubusercontent.com/2405631/230608059-82b41b05-fbe8-40e3-88c9-22b366672f07.png)
And the user is then expected to enter the full url to access the UI of their nightscout domain (for example mine is `https://cgm.ddellspe.net` so with entering that, I get the watch face properly pulling data:
![image](https://user-images.githubusercontent.com/2405631/230608250-4ca7396f-14f5-4273-bcdd-5ef672bf22ae.png)

All images are from the simulator as my device (Sense 2) isn't supported as a development device in the fitbit sdk still.
