### PR TITLE
Add token input and update query parameters

### DIFF
--- a/modules/companion/settings.js
+++ b/modules/companion/settings.js
@@ -77,6 +77,13 @@ export default class settings {
         );
       }
 
+      if (settingsStorage.getItem("nightscoutToken")) {
+        let nightscoutToken = JSON.parse(
+          settingsStorage.getItem("nightscoutToken")
+        ).name;
+        queryParms += "&token=" + nightscoutToken;
+      }
+
       if(nightscoutSiteHost === "") {
         url =
           nightscoutSiteName.toLowerCase() +

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -100,6 +100,17 @@ function mySettings(props) {
         ) : null}
 
         {props.settings.dataSource ? (
+          JSON.parse(props.settings.dataSource).values[0].value ==
+          "nightscout" ? (
+            <TextInput
+              title="Nightscout Token"
+              label="Nightscout Token"
+              settingsKey="nightscoutToken"
+            />
+          ) : null
+        ) : null}
+
+        {props.settings.dataSource ? (
           JSON.parse(props.settings.dataSource).values[0].value == "dexcom" ? (
             <Section
               title={


### PR DESCRIPTION
Adds a "Nightscout Token" input when the data source is Nightscout, this is optional and if present will update the query parameters appropriately.  This applies to all variants of Nightscout configurations.

![image](https://user-images.githubusercontent.com/2405631/230681612-3183e8a1-993e-4d39-a0d8-fb88f356908e.png)
